### PR TITLE
Adding [declarations] clause fixes `npx flow` errors

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,3 +7,7 @@
 [lints]
 
 [options]
+
+[declarations]
+<PROJECT_ROOT>/node_modules/resolve/.*
+


### PR DESCRIPTION
Fixes the below error when running `npx flow`

```
> queue-promise@2.2.1 test:flow
> npx flow

Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/resolve/test/resolver/malformed_package_json/package.json:2:1

Unexpected end of input, expected the token }

     1│ {
     2│



Found 1 error
```